### PR TITLE
uppdate certificates/tasks/main.yml

### DIFF
--- a/roles/certificates/tasks/main.yml
+++ b/roles/certificates/tasks/main.yml
@@ -86,6 +86,9 @@
     - path: /etc/pki/mantl/key
       mode: "0640"
       group: tls
+    - path: /etc/pki/CA/ca.cert
+      mode: "0644"
+      group: root
   tags:
     - certificates
 


### PR DESCRIPTION
changing file mode on /etc/pki/CA/ca.cert
consul user did not have access to the cert with 600 root:root access set

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
