### PR TITLE
Update consul-wait-for-leader.sh

### DIFF
--- a/roles/consul/files/consul-wait-for-leader.sh
+++ b/roles/consul/files/consul-wait-for-leader.sh
@@ -9,7 +9,7 @@ fi
 max_wait=30
 
 while :; do
-  if [[ $(consul-cli status-leader ${ccargs}) =~ [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*:[0-9]* ]]; then
+  if [[ $(consul-cli status leader ${ccargs}) =~ [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*:[0-9]* ]]; then
     exit 0
   fi
 


### PR DESCRIPTION
consul-cli status-leader is deprecated
changing to consul-cli status leader

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
